### PR TITLE
Expand the scope of the Toolkit

### DIFF
--- a/bmt/utils.py
+++ b/bmt/utils.py
@@ -1,0 +1,135 @@
+import re
+
+import stringcase
+from biolinkml.meta import Definition, ClassDefinition, SlotDefinition, Element, ClassDefinitionName, \
+    SlotDefinitionName, ElementName, TypeDefinition
+
+
+def camelcase_to_sentencecase(s: str) -> str:
+    """
+    Convert CamelCase to sentence case.
+
+    Parameters
+    ----------
+    s: str
+        Input string in CamelCase
+    Returns
+    -------
+    str
+        string in sentence case form
+    """
+    return stringcase.sentencecase(s).lower()
+
+
+def snakecase_to_sentencecase(s: str) -> str:
+    """
+    Convert snake_case to sentence case.
+
+    Parameters
+    ----------
+    s: str
+        Input string in snake_case
+    Returns
+    -------
+    str
+        string in sentence case form
+    """
+    return stringcase.sentencecase(s).lower()
+
+
+def sentencecase_to_snakecase(s: str) -> str:
+    """
+    Convert sentence case to snake_case.
+
+    Parameters
+    ----------
+    s: str
+        Input string in sentence case
+    Returns
+    -------
+    str
+        string in snake_case form
+    """
+    return stringcase.snakecase(s).lower()
+
+
+def sentencecase_to_camelcase(s: str) -> str:
+    """
+    Convert sentence case to CamelCase.
+    Parameters
+    ----------
+    s: str
+        Input string in sentence case
+    Returns
+    -------
+    str
+        string in CamelCase form
+    """
+    return stringcase.pascalcase(stringcase.snakecase(s))
+
+
+def format_element(element: Element) -> str:
+    """
+    Format a given element's name.
+
+    Parameters
+    ----------
+    element: biolinkml.meta.Element
+        An element
+
+    Returns
+    -------
+    str
+        A CURIE representation of an element's name
+
+    """
+    if isinstance(element, ClassDefinitionName):
+        formatted = f"biolink:{sentencecase_to_camelcase(element)}"
+    elif isinstance(element, ClassDefinition):
+        formatted = f"biolink:{sentencecase_to_camelcase(element.name)}"
+    elif isinstance(element, SlotDefinitionName):
+        formatted = f"biolink:{sentencecase_to_snakecase(element)}"
+    elif isinstance(element, SlotDefinition):
+        formatted = f"biolink:{sentencecase_to_snakecase(element.name)}"
+    elif isinstance(element, TypeDefinition):
+        if element.from_schema == 'https://w3id.org/biolink/biolinkml/types':
+            formatted = f"metatype:{sentencecase_to_camelcase(element.name)}"
+        else:
+            formatted = f"biolink:{sentencecase_to_camelcase(element.name)}"
+    else:
+        if isinstance(element, ElementName):
+            formatted = f"biolink:{sentencecase_to_camelcase(element)}"
+        else:
+            formatted = f"biolink:{sentencecase_to_camelcase(element.name)}"
+    return formatted
+
+
+def parse_name(name) -> str:
+    """
+    Parse an element name into it's proper internal representation.
+
+    Parameters
+    ----------
+    name: str
+        An element name
+
+    Returns
+    -------
+    str
+        An internal representation of the given name
+
+    """
+    actual_name = name
+    if name.startswith("biolink"):
+        m = re.match("biolink:(.+)", name)
+        if m:
+            r = m.groups()[0]
+            if '_' in r:
+                actual_name = snakecase_to_sentencecase(r)
+            else:
+                actual_name = camelcase_to_sentencecase(r)
+    elif '_' in name:
+        actual_name = snakecase_to_sentencecase(name)
+    else:
+        actual_name = camelcase_to_sentencecase(name)
+    return actual_name

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 biolinkml>=1.5.10
 deprecation>=2.0.6
+stringcase>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 biolinkml>=1.5.10
 deprecation>=2.0.6
 stringcase>=1.0.0
+pbr

--- a/test/unit/test_toolkit.py
+++ b/test/unit/test_toolkit.py
@@ -1,6 +1,75 @@
 from bmt import Toolkit
 
 
+def test_get_all_elements():
+    toolkit = Toolkit()
+    elements = toolkit.get_all_elements()
+    assert 'named thing' in elements
+    assert 'association' in elements
+    assert 'related to' in elements
+    assert 'uriorcurie' in elements
+
+    elements = toolkit.get_all_elements(formatted=True)
+    assert 'biolink:NamedThing' in elements
+    assert 'biolink:GeneToGeneAssociation' in elements
+    assert 'biolink:related_to' in elements
+    assert 'metatype:Uriorcurie' in elements
+    assert 'biolink:Frequency' in elements
+
+
+def test_get_all_entities():
+    toolkit = Toolkit()
+    entities = toolkit.get_all_entities()
+    assert 'named thing' in entities
+    assert 'gene' in entities
+    assert 'disease' in entities
+    assert 'association' not in entities
+    assert 'related to' not in entities
+
+    entities = toolkit.get_all_entities(formatted=True)
+    assert 'biolink:NamedThing' in entities
+    assert 'biolink:Gene' in entities
+    assert 'biolink:Disease' in entities
+
+
+def test_get_all_associations():
+    toolkit = Toolkit()
+    associations = toolkit.get_all_associations()
+    assert 'association' in associations
+    assert 'gene to gene association' in associations
+    assert 'named thing' not in associations
+
+    associations = toolkit.get_all_associations(formatted=True)
+    assert 'biolink:Association' in associations
+    assert 'biolink:GeneToGeneAssociation' in associations
+
+
+def test_get_all_node_properties():
+    toolkit = Toolkit()
+    properties = toolkit.get_all_node_properties()
+    assert 'name' in properties
+    assert 'category' in properties
+    assert 'has gene' in properties
+
+    properties = toolkit.get_all_node_properties(formatted=True)
+    assert 'biolink:name' in properties
+    assert 'biolink:category' in properties
+    assert 'biolink:has_gene' in properties
+
+
+def test_get_all_edge_properties():
+    toolkit = Toolkit()
+    properties = toolkit.get_all_edge_properties()
+    assert 'subject' in properties
+    assert 'object' in properties
+    assert 'frequency qualifier' in properties
+
+    properties = toolkit.get_all_edge_properties(formatted=True)
+    assert 'biolink:subject' in properties
+    assert 'biolink:object' in properties
+    assert 'biolink:frequency_qualifier' in properties
+
+
 def test_get_element():
     toolkit = Toolkit()
     gene = toolkit.get_element('gene')
@@ -26,11 +95,15 @@ def test_category():
 def test_ancestors():
     toolkit = Toolkit()
     assert 'related to' in toolkit.get_ancestors('causes')
+    assert 'biolink:related_to' in toolkit.get_ancestors('causes', formatted=True)
+
     assert 'named thing' in toolkit.get_ancestors('gene')
+    assert 'biolink:NamedThing' in toolkit.get_ancestors('gene', formatted=True)
 
     assert 'causes' in toolkit.get_ancestors('causes')
     assert 'causes' in toolkit.get_ancestors('causes', reflexive=True)
     assert 'causes' not in toolkit.get_ancestors('causes', reflexive=False)
+    assert 'biolink:causes' in toolkit.get_ancestors('causes', reflexive=True, formatted=True)
 
 
 def test_descendants():
@@ -39,10 +112,12 @@ def test_descendants():
     assert 'interacts with' in toolkit.get_descendants('related to')
     assert 'gene' in toolkit.get_descendants('named thing')
     assert 'phenotypic feature' in toolkit.get_descendants('named thing')
+    assert 'biolink:PhenotypicFeature' in toolkit.get_descendants('named thing', formatted=True)
 
     assert 'genomic entity' in toolkit.get_ancestors('genomic entity')
     assert 'genomic entity' in toolkit.get_ancestors('genomic entity', reflexive=True)
     assert 'genomic entity' not in toolkit.get_ancestors('genomic entity', reflexive=False)
+    assert 'biolink:GenomicEntity' in toolkit.get_ancestors('gene', formatted=True)
 
 
 def test_children():
@@ -50,6 +125,7 @@ def test_children():
     assert 'causes' in toolkit.get_children('contributes to')
     assert 'physically interacts with' in toolkit.get_children('interacts with')
     assert 'gene' in toolkit.get_children('gene or gene product')
+    assert 'biolink:Gene' in toolkit.get_children('gene or gene product', formatted=True)
 
 
 def test_parent():
@@ -57,6 +133,7 @@ def test_parent():
     assert 'contributes to' in toolkit.get_parent('causes')
     assert 'interacts with' in toolkit.get_parent('physically interacts with')
     assert 'gene or gene product' in toolkit.get_parent('gene')
+    assert 'biolink:GeneOrGeneProduct' in toolkit.get_parent('gene or gene product', formatted=True)
 
 
 def test_mapping():
@@ -72,4 +149,4 @@ def test_mapping():
 
     assert len(toolkit.get_all_elements_by_mapping('RO:0004033')) == 1
     assert 'negatively regulates' in toolkit.get_all_elements_by_mapping('RO:0004033')
-
+    assert 'biolink:negatively_regulates' in toolkit.get_all_elements_by_mapping('RO:0004033', formatted=True)

--- a/test/unit/test_toolkit.py
+++ b/test/unit/test_toolkit.py
@@ -28,6 +28,10 @@ def test_ancestors():
     assert 'related to' in toolkit.get_ancestors('causes')
     assert 'named thing' in toolkit.get_ancestors('gene')
 
+    assert 'causes' in toolkit.get_ancestors('causes')
+    assert 'causes' in toolkit.get_ancestors('causes', reflexive=True)
+    assert 'causes' not in toolkit.get_ancestors('causes', reflexive=False)
+
 
 def test_descendants():
     toolkit = Toolkit()
@@ -35,6 +39,10 @@ def test_descendants():
     assert 'interacts with' in toolkit.get_descendants('related to')
     assert 'gene' in toolkit.get_descendants('named thing')
     assert 'phenotypic feature' in toolkit.get_descendants('named thing')
+
+    assert 'genomic entity' in toolkit.get_ancestors('genomic entity')
+    assert 'genomic entity' in toolkit.get_ancestors('genomic entity', reflexive=True)
+    assert 'genomic entity' not in toolkit.get_ancestors('genomic entity', reflexive=False)
 
 
 def test_children():

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from bmt.utils import parse_name
+
+
+@pytest.mark.parametrize('query', [
+    ('biolink:Gene', 'gene'),
+    ('biolink:NamedThing', 'named thing'),
+    ('biolink:related_to', 'related to'),
+    ('PhenotypicFeature', 'phenotypic feature'),
+    ('related_to', 'related to'),
+    ('related to', 'related to'),
+    ('causes', 'causes'),
+    ('treats', 'treats'),
+    ('gene', 'gene'),
+    ('has_gene', 'has gene'),
+    ('biolink:GeneToGeneAssociation', 'gene to gene association'),
+])
+def test_parse_name(query):
+    n = parse_name(query[0])
+    assert n == query[1]
+


### PR DESCRIPTION
This PR address the following,
- Add `reflexive` option to `get_ancestors` and `get_descendants` (Addresses #8)
- Add `formatted` option to return elements formatted as CURIEs
- Add support for parsing biolink names in `sentence case`, `CamelCase`, and `snake_case` (Addresses #9)
- Deprecate `names` method and add `get_all_elements` instead (Addresses #7)
- Add new methods to Toolkit class,
  - `get_all_classes`
  - `get_all_slots`
  - `get_all_types`
  - `get_all_entities`
  - `get_all_associations`
  - `get_all_node_properties`
  - `get_all_edge_properties`
- Call for slots now filters out slots that are not primary
