### PR TITLE
small comment fix

### DIFF
--- a/bmt/toolkit.py
+++ b/bmt/toolkit.py
@@ -193,8 +193,7 @@ class Toolkit(object):
             A list of elements
 
         """
-        elements = self.get_descendants("association")
-        return self._format_all_elements(elements, formatted)
+        return self.get_descendants("association", formatted=formatted)
 
     @lru_cache(CACHE_SIZE)
     def get_all_node_properties(self, formatted: bool = False) -> List[str]:

--- a/bmt/toolkit.py
+++ b/bmt/toolkit.py
@@ -417,11 +417,11 @@ class Toolkit(object):
         name: str
             The name of an element in the Biolink Model
         reflexive: bool
-            Whether to include the query element in the list of ancestors
+            Whether to include the query element in the list of descendants
         formatted: bool
             Whether to format element names as CURIEs
         mixin: bool
-            If True, then that means we want to find mixin ancestors as well as is_a ancestors
+            If True, then that means we want to find mixin descendants as well as is_a ancestors
 
         Returns
         -------


### PR DESCRIPTION
This looks like a copy 'n paste erratum: should 'ancestors' be 'descendants' in the method comment of this method?