### PR TITLE
Encapsulated management of ToolKit error messages 

### DIFF
--- a/bmt/toolkit.py
+++ b/bmt/toolkit.py
@@ -404,8 +404,20 @@ class Toolkit(object):
 
     @staticmethod
     def warning(identifier: str, context: str, template: str) -> None:
+        # First iteration: simple wrapper of original Python logging call,
+        # replicates original logging behaviour except the line number
+        # (is the Toolkit.warning() method line number)
         msg = f"{context}(): {template.format(id=identifier)}"
         logger.warning(msg)
+
+    def clear_warnings(self):
+        pass
+
+    def get_warnings(self, context: str) -> Dict[str, List[str]]:
+        pass
+
+    def get_all_warnings(self) -> Dict[str, Dict[str, List[str]]]:
+        pass
 
     def get_associations(
             self,

--- a/bmt/toolkit.py
+++ b/bmt/toolkit.py
@@ -6,8 +6,6 @@ from functools import lru_cache, reduce
 
 from typing import List, Union, TextIO, Optional, Dict, Set
 
-from copy import deepcopy
-
 from linkml_runtime.linkml_model import PermissibleValueText
 from linkml_runtime.utils.schemaview import SchemaView
 from linkml_runtime.linkml_model.meta import (

--- a/bmt/toolkit.py
+++ b/bmt/toolkit.py
@@ -446,7 +446,7 @@ class Toolkit(object):
 
         template: str = cls._warning_msg_templates[context]
         identifiers_str = ", ".join(identifiers)
-        return f"{context}: {template.format(ids=identifiers_str)}"
+        return f"{context} | {template.format(ids=identifiers_str)}"
 
     # indexed list of identifiers captured in a given warning context
     _warning_id_catalog: Dict[str, Set[str]] = {}

--- a/bmt/toolkit.py
+++ b/bmt/toolkit.py
@@ -402,6 +402,11 @@ class Toolkit(object):
             return False
         return True
 
+    @staticmethod
+    def warning(identifier: str, context: str, template: str) -> None:
+        msg = f"{context}(): {template.format(id=identifier)}"
+        logger.warning(msg)
+
     def get_associations(
             self,
             subject_categories: Optional[List[str]] = None,
@@ -458,9 +463,10 @@ class Toolkit(object):
             for sc in subject_categories:
                 sc_elem = self.get_element(sc)
                 if not sc_elem:
-                    logger.warning(
-                        f"get_associations(): could not find subject category " +
-                        f"element '{str(sc)}' in current Biolink Model release?"
+                    self.warning(
+                        identifier=str(sc),
+                        context="get_associations",
+                        template="could not find subject category element '{id}' in current Biolink Model release?"
                     )
                     return []
                 sc_formatted = format_element(sc_elem)
@@ -470,9 +476,10 @@ class Toolkit(object):
             for oc in object_categories:
                 oc_elem = self.get_element(oc)
                 if not oc_elem:
-                    logger.warning(
-                        f"get_associations(): could not find object category " +
-                        f"element '{str(oc)}' in current Biolink Model release?"
+                    self.warning(
+                        identifier=str(oc),
+                        context="get_associations",
+                        template="could not find object category element '{id}' in current Biolink Model release?"
                     )
                     return []
                 oc_formatted = format_element(oc_elem)
@@ -482,9 +489,10 @@ class Toolkit(object):
             for pred in predicates:
                 p_elem = self.get_element(pred)
                 if not p_elem:
-                    logger.warning(
-                        f"get_associations(): could not find predicate " +
-                        f"element '{str(pred)}' in current Biolink Model release?"
+                    self.warning(
+                        identifier=str(pred),
+                        context="get_associations",
+                        template="could not find predicate element '{id}' in current Biolink Model release?"
                     )
                     return []
                 pred_formatted = format_element(p_elem)
@@ -501,9 +509,11 @@ class Toolkit(object):
                 inverse_p = self.get_inverse(p_elem.name)
                 if not inverse_p:
                     # might be a symmetrical predicate or a predicate lacking an inverse
-                    logger.warning(
-                        f"get_associations(): predicate '{str(p_elem.name)}' is symmetric or " +
-                        "does not have an inverse, within the current Biolink Model release?"
+                    self.warning(
+                        identifier=str(p_elem.name),
+                        context="get_associations",
+                        template="predicate '{id}' is symmetric or does not have "
+                                 "an inverse, within the current Biolink Model release?"
                     )
                 else:
                     inverse_pred_formatted = format_element(inverse_p)
@@ -522,9 +532,11 @@ class Toolkit(object):
                 if not association:
                     # TODO: unsure that this test is needed, since all
                     #       known association classes ought to have names?
-                    logger.warning(
-                        f"get_associations(): association name '{str(name)}' " +
-                        f"does not match any element in the current Biolink Model release?"
+                    self.warning(
+                        identifier=str(name),
+                        context="get_associations",
+                        template="association name '{id}' does not match "
+                                "any element in the current Biolink Model release?"
                     )
                     continue
 
@@ -1890,7 +1902,11 @@ class Toolkit(object):
                 if hasattr(element, 'id_prefixes') and prefix in element.id_prefixes:
                     categories.append(element.name)
         if len(categories) == 0:
-            logger.warning("no biolink class found for the given curie: %s, try get_element_by_mapping?", identifier)
+            self.warning(
+                identifier=identifier,
+                context="get_element_by_prefix",
+                template="no biolink class found for the given curie: {id}, try get_element_by_mapping?"
+            )
 
         return categories
 

--- a/bmt/toolkit.py
+++ b/bmt/toolkit.py
@@ -23,9 +23,9 @@ Path = str
 
 LATEST_BIOLINK_RELEASE = "4.2.2"
 
-REMOTE_PATH = f"https://raw.githubusercontent.com/biolink/biolink-model/v{LATEST_BIOLINK_RELEASE}/biolink-model.yaml"
-PREDICATE_MAP = f"https://raw.githubusercontent.com/biolink/biolink-model/v{LATEST_BIOLINK_RELEASE}/predicate_mapping.yaml"
-
+BIOLINK_MODEL_RAW_BASEURL = f"https://raw.githubusercontent.com/biolink/biolink-model/v{LATEST_BIOLINK_RELEASE}/"
+REMOTE_PATH = f"{BIOLINK_MODEL_RAW_BASEURL}biolink-model.yaml"
+PREDICATE_MAP = f"{BIOLINK_MODEL_RAW_BASEURL}predicate_mapping.yaml"
 
 NODE_PROPERTY = "node property"
 ASSOCIATION_SLOT = "association slot"
@@ -753,8 +753,9 @@ class Toolkit(object):
         return parent
 
     @lru_cache(CACHE_SIZE)
-    def get_permissible_value_children(self, permissible_value: str, enum_name: str) -> Union[
-        str, PermissibleValueText, None]:
+    def get_permissible_value_children(
+            self, permissible_value: str, enum_name: str
+    ) -> Union[str, PermissibleValueText, None]:
         """
         Gets the children of a permissible value in an enumeration.
 
@@ -970,9 +971,9 @@ class Toolkit(object):
                 if el.name.lower() == name.lower():
                     element = el
 
-        if type(element) == ClassDefinition and element.class_uri is None:
+        if isinstance(element, ClassDefinition) and element.class_uri is None:
             element.class_uri = format_element(element)
-        if type(element) == SlotDefinition and element.slot_uri is None:
+        if isinstance(element, SlotDefinition) and element.slot_uri is None:
             element.slot_uri = format_element(element)
         return element
 

--- a/docs/intro/example_usage.md
+++ b/docs/intro/example_usage.md
@@ -118,3 +118,43 @@ t = Toolkit('/path/to/biolink-model.yaml')
 ```
 
 The path can be a file path or a URL.
+
+## Extraordinary Toolkit Warnings
+
+The Toolkit tracks additional warnings generated about specific data elements by some methods like `get_associations` and `get_element_by_prefix`, but leaves it to the user to print them out.
+
+These warnings are automatically tracked within the Toolkit and accessed by calling the dump function as follows:
+
+```py
+from bmt import Toolkit
+from sys import stderr
+t = Toolkit()
+# calls made to `get_associations` and `get_element_by_prefix` with possible invalid elements...
+warnings: str = t.dump_warnings() 
+print(warnings)
+```
+
+should print something similar to this (obviously rather with the specific error contexts and identifiers which were seen)
+
+```
+get_associations_object_category: Could not find object category elements:
+	'biolink:NotACategory, NCBIGene:1010'
+within the current Biolink Model release?
+
+get_element_by_prefix_missing_element: No Biolink class found for the given curies:
+	'foo:bar'
+...try 'get_element_by_mapping'?
+
+get_associations_missing_association: Associations:
+	'biolink:NotAnAssociation'
+does not match any association class within the current Biolink Model release?
+```
+
+You can reset the warning tracking log anytime as follows (the following assertion should work...)
+
+```py
+
+t.clear_warnings()
+warnings = t.dump_warnings() 
+assert warnings == ""
+```

--- a/tests/unit/test_toolkit.py
+++ b/tests/unit/test_toolkit.py
@@ -93,6 +93,16 @@ def test_get_model_version(toolkit):
     assert version == LATEST_BIOLINK_RELEASE
 
 
+def test_warning(toolkit, caplog):
+    # First iteration: the Toolkit.warning() method simply
+    # replicates the behaviour of the old Python logger behaviour
+    identifier = "SomeID"
+    context = "test_warning"
+    template = "this is a template to echo the '{id}'!"
+    toolkit.warning(identifier=identifier, context=context, template=template)
+    assert caplog.text.endswith("test_warning(): this is a template to echo the 'SomeID'!\n")
+
+
 def test_sv(toolkit):
     v = toolkit.view
     ancs = v.slot_ancestors('broad match')

--- a/tests/unit/test_toolkit.py
+++ b/tests/unit/test_toolkit.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional, List, Dict
 
 import pytest
@@ -93,14 +94,38 @@ def test_get_model_version(toolkit):
     assert version == LATEST_BIOLINK_RELEASE
 
 
-def test_warning(toolkit, caplog):
-    # First iteration: the Toolkit.warning() method simply
-    # replicates the behaviour of the old Python logger behaviour
-    identifier = "SomeID"
-    context = "test_warning"
-    template = "this is a template to echo the '{id}'!"
-    toolkit.warning(identifier=identifier, context=context, template=template)
-    assert caplog.text.endswith("test_warning(): this is a template to echo the 'SomeID'!\n")
+def test_warnings(toolkit):
+
+    # only certain contexts are legitimate
+    with pytest.raises(AssertionError):
+        toolkit._format_warning_msg(context="invalid-context", identifiers={"1", "2", "3"})
+
+    identifier = "HGNC:1234"
+    context = "get_associations_subject_category"
+    toolkit.warning(context=context, identifier=identifier)
+    warnings: str = toolkit.dump_warnings()
+    assert warnings.endswith(
+        "get_associations_subject_category: "
+        "Could not find subject category elements:\n\t'HGNC:1234'\n"
+        "within the current Biolink Model release?\n\n"
+    )
+
+    toolkit.clear_warnings()
+    warnings = toolkit.dump_warnings()
+    assert warnings == ""
+
+    # check the unit test console for a display of the following messages
+    context = "get_associations_object_category"
+    toolkit.warning(context=context, identifier="biolink:NotACategory")
+    toolkit.warning(context=context, identifier="NCBIGene:1010")
+
+    context = "get_element_by_prefix_missing_element"
+    toolkit.warning(context=context, identifier="foo:bar")
+
+    context = "get_associations_missing_association"
+    toolkit.warning(context=context, identifier="biolink:NotAnAssociation")
+
+    print("\n\n"+toolkit.dump_warnings(), file=sys.stderr)
 
 
 def test_sv(toolkit):

--- a/tests/unit/test_toolkit.py
+++ b/tests/unit/test_toolkit.py
@@ -105,7 +105,7 @@ def test_warnings(toolkit):
     toolkit.warning(context=context, identifier=identifier)
     warnings: str = toolkit.dump_warnings()
     assert warnings.endswith(
-        "get_associations_subject_category: "
+        "get_associations_subject_category | "
         "Could not find subject category elements:\n\t'HGNC:1234'\n"
         "within the current Biolink Model release?\n\n"
     )


### PR DESCRIPTION
Python logging output from mainstream functions `get_associations` and `get_element_by_prefix` replaced with an embedded warning message logger under more direct BMT user control.