### PR TITLE
setting version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bmt"
-version = "0.0.0"
+version = "1.4.6"
 description = "Biolink Model Toolkit: A Python API for working with the Biolink Model"
 authors = [
     {name="Sierra Taylor Moxon", email="sierra.taylor@gmail.com"},


### PR DESCRIPTION
Having a version of "0.0.0" doesn't allow projects using a git source override such as translator-ingests to resolve dependencies that require a minimum version > 0.0.0. This would resolve that issue. Then the version can be updated as new releases are made.