### PR TITLE
Deprecated entity_id() method

### DIFF
--- a/src/bmt/pydantic.py
+++ b/src/bmt/pydantic.py
@@ -12,19 +12,6 @@ from bmt import Toolkit
 toolkit = Toolkit()
 logger = logging.getLogger(__name__)
 
-
-def entity_id() -> str:
-    """
-    Generate a unique identifier for a Biolink Model entity.
-
-    Returns
-    -------
-    str
-        unique identifier
-    """
-    return uuid4().urn
-
-
 def infores(identifier: str) -> str:
     """
     Coerce the specified identifier to the Biolink Model infores namespace.
@@ -128,7 +115,7 @@ def _build_retrieval_source(
         resource_id = source_spec
         source_record_urls = None
     return pyd.RetrievalSource(
-        id=entity_id(),
+        id=str(uuid4()),
         resource_id=infores(resource_id),
         resource_role=resource_role,
         source_record_urls=source_record_urls,

--- a/tests/unit/test_pydantic.py
+++ b/tests/unit/test_pydantic.py
@@ -5,7 +5,6 @@ import biolink_model.datamodel.pydanticmodel_v2 as pyd
 import pytest
 from bmt import Toolkit
 from bmt.pydantic import (
-    entity_id,
     infores,
     get_node_class,
     get_edge_class,
@@ -15,9 +14,6 @@ from bmt.pydantic import (
 @pytest.fixture(scope="module")
 def toolkit():
     return Toolkit()
-
-def test_entity_id():
-    assert entity_id().startswith("urn:uuid:")
 
 def test_infores():
     with pytest.raises(AssertionError):


### PR DESCRIPTION
Removed entity_id function and replaced its usage locally with a direct UUID generation without prefix (only currently used in the Association.sources RetrievalSource objects)