### PR TITLE
Switch from `stringcase` to `casefy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "deprecation>=2.1.0,<3.0.0",
-    "stringcase>=1.2.0,<2.0.0",
+    "casefy>=1.1.0,<2.0.0",
     "biolink-model>=4.4.3,<5.0.0",
 ]
 

--- a/src/bmt/utils.py
+++ b/src/bmt/utils.py
@@ -1,6 +1,6 @@
 import re
 
-import stringcase
+import casefy
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
     SlotDefinition,
@@ -53,7 +53,7 @@ def snakecase_to_sentencecase(s: str) -> str:
     str
         string in sentence case form
     """
-    return stringcase.sentencecase(s).lower()
+    return casefy.sentencecase(s).lower()
 
 
 def sentencecase_to_snakecase(s: str) -> str:
@@ -69,7 +69,7 @@ def sentencecase_to_snakecase(s: str) -> str:
     str
         string in snake_case form
     """
-    return stringcase.snakecase(s).lower()
+    return casefy.snakecase(s).lower()
 
 
 def sentencecase_to_camelcase(s: str) -> str:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,13 @@
 from bmt.toolkit import Toolkit
 import pytest
 
-from bmt.utils import parse_name, format_element, sentencecase_to_camelcase
+from bmt.utils import (
+    parse_name,
+    format_element,
+    sentencecase_to_camelcase,
+    sentencecase_to_snakecase,
+    snakecase_to_sentencecase,
+)
 
 
 @pytest.fixture(scope="module")
@@ -32,6 +38,109 @@ def toolkit():
 def test_parse_name(query):
     n = parse_name(query[0])
     assert n == query[1]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        ("related_to", "related to"),
+        ("has_gene_product", "has gene product"),
+        ("gene_product_of", "gene product of"),
+        ("physically_interacts_with", "physically interacts with"),
+        ("in_taxon", "in taxon"),
+        ("subclass_of", "subclass of"),
+        ("has_qualitative_form_or_quantity", "has qualitative form or quantity"),
+        ("colocalizes_with", "colocalizes with"),
+        ("max_research_phase", "max research phase"),
+        # Already sentence case, or a single word: unchanged apart from folding.
+        ("affects", "affects"),
+        ("", ""),
+    ],
+)
+def test_snakecase_to_sentencecase(query):
+    n = snakecase_to_sentencecase(query[0])
+    assert n == query[1]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        ("related to", "related_to"),
+        ("has gene product", "has_gene_product"),
+        ("gene product of", "gene_product_of"),
+        ("physically interacts with", "physically_interacts_with"),
+        ("in taxon", "in_taxon"),
+        ("subclass of", "subclass_of"),
+        ("gene or gene product", "gene_or_gene_product"),
+        ("named thing", "named_thing"),
+        ("log odds ratio 95 ci", "log_odds_ratio_95_ci"),
+        ("affects", "affects"),
+        ("", ""),
+    ],
+)
+def test_sentencecase_to_snakecase(query):
+    n = sentencecase_to_snakecase(query[0])
+    assert n == query[1]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # An embedded acronym is split into one segment per letter, and the
+        # boundary before it is *not* doubled the way stringcase doubled it
+        # ("highest__f_d_a_approval_status", "noncoding__r_n_a_product").
+        ("highest FDA approval status", "highest_f_d_a_approval_status"),
+        ("noncoding RNA product", "noncoding_r_n_a_product"),
+    ],
+)
+def test_sentencecase_to_snakecase_acronyms(query):
+    """
+    Pin how acronyms fall out of ``sentencecase_to_snakecase``.
+
+    Neither the current output nor stringcase's reproduces the model's own
+    ``biolink:highest_FDA_approval_status``, so this is not a correctness
+    assertion -- it records the shape callers actually get, so that any future
+    change to it is a deliberate one.
+    """
+    n = sentencecase_to_snakecase(query[0])
+    assert n == query[1]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # Digit runs are split per digit, so this does not round-trip back to
+        # the model's "log odds ratio 95 ci"; get_element only still resolves
+        # it because of the separator-insensitive fallback in Toolkit.
+        ("log_odds_ratio_95_ci", "log odds ratio 9 5 ci"),
+        ("1_to_1", "1 to 1"),
+    ],
+)
+def test_snakecase_to_sentencecase_digits(query):
+    n = snakecase_to_sentencecase(query[0])
+    assert n == query[1]
+
+
+def test_format_element_round_trips_for_every_element(toolkit):
+    """
+    Every class and slot in the model must survive name -> CURIE -> name.
+
+    This is the property the case-conversion helpers exist to serve, so it is
+    the guard that matters if they are ever swapped out again. ``metatype:``
+    CURIEs from the linkml types schema are excluded: ``parse_name`` only
+    understands the ``biolink:`` prefix, so they have never round-tripped.
+    """
+    failures = []
+    for name in sorted(set(toolkit.get_all_elements())):
+        element = toolkit.get_element(name)
+        assert element is not None, f"{name} is listed but does not resolve"
+        curie = format_element(element)
+        if curie.startswith("metatype:"):
+            continue
+        resolved = toolkit.get_element(curie)
+        if resolved is None or resolved.name != element.name:
+            failures.append((name, curie, resolved.name if resolved else None))
+    assert not failures
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -193,8 +193,8 @@ name = "bmt"
 source = { editable = "." }
 dependencies = [
     { name = "biolink-model" },
+    { name = "casefy" },
     { name = "deprecation" },
-    { name = "stringcase" },
 ]
 
 [package.dev-dependencies]
@@ -209,8 +209,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "biolink-model", specifier = ">=4.4.3,<5.0.0" },
+    { name = "casefy", specifier = ">=1.1.0,<2.0.0" },
     { name = "deprecation", specifier = ">=2.1.0,<3.0.0" },
-    { name = "stringcase", specifier = ">=1.2.0,<2.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -220,6 +220,15 @@ dev = [
     { name = "sphinx", specifier = ">=5.3.0,<6.0.0" },
     { name = "sphinx-rtd-theme", specifier = ">=1.3.0,<2.0.0" },
     { name = "sphinxcontrib-napoleon", specifier = ">=0.7,<1.0" },
+]
+
+[[package]]
+name = "casefy"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/24/9c732e8e3585a1dc621c9c1349e55e87070c95d3c2d57bd8c5083ec8d731/casefy-1.1.0.tar.gz", hash = "sha256:849d6e0f80506fac70ab8e18999a4ca1eb7d8f70941682383d64aa22a7497f8f", size = 123884, upload-time = "2025-03-07T14:36:44.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/6a/1766f8c163951a3c9aeb30a4e6f5de9b2eed8389e3906c4cf30fcb475be6/casefy-1.1.0-py3-none-any.whl", hash = "sha256:a3dfcb14d85902d90702db1e9835760237f6a73ec0ae3b7e991ad767513a3cbc", size = 6539, upload-time = "2025-03-07T14:36:37.546Z" },
 ]
 
 [[package]]
@@ -461,7 +470,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,13 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+biolink-model = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+
 [[package]]
 name = "alabaster"
 version = "0.7.16"


### PR DESCRIPTION
`stringcase` is stale and causes deprecation warnings, as well as install, issues on Python 3.12+. `casefy` is a viable, drop-in alternative.

A brief test to compare the two:

```python
import casefy
import stringcase

SNAKE_INPUTS = [  # snake_case fragments -> sentence case
    "related_to", "has_gene_product", "gene_product_of", "affects",
    "physically_interacts_with", "in_taxon", "subclass_of",
    "has_qualitative_form_or_quantity", "colocalizes_with", "1_to_1",
]
SENTENCE_INPUTS = [  # sentence case -> snake_case
    "related to", "has gene product", "gene product of", "affects",
    "physically interacts with", "in taxon", "subclass of",
    "gene or gene product", "named thing",
    "3'UTR",  # synthetic edge case: only place the two libraries differ
]

mismatches = []
sk_len = max(map(len, SNAKE_INPUTS)) + 2
st_len = max(map(len, SNAKE_INPUTS)) + 2

print("snakecase_to_sentencecase:  sentencecase(s).lower()")
for s in SNAKE_INPUTS:
    a = stringcase.sentencecase(s).lower()
    b = casefy.sentencecase(s).lower()
    if a != b:
        mismatches.append(s)
    print(f"  {'OK  ' if a == b else 'DIFF'}  {s!r:{sk_len}} stringcase={a!r:{st_len}} casefy={b!r}")

print("\nsentencecase_to_snakecase:  snakecase(s).lower()")
for s in SENTENCE_INPUTS:
    a = stringcase.snakecase(s).lower()
    b = casefy.snakecase(s).lower()
    if a != b:
        mismatches.append(s)
    print(f"  {'OK  ' if a == b else 'DIFF'}  {s!r:{st_len}} stringcase={a!r:{sk_len}} casefy={b!r}")

print(f"\n{len(mismatches)} mismatch(es): {mismatches}")
```

We end up with one difference, `3'UTR`, which is fairly different from anything bmt should be dealing with.